### PR TITLE
Remove Serializer

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -118,7 +118,7 @@
     "disallowTrailingWhitespace" : true,
     "disallowKeywordsOnNewLine" : ["else"],
     "requireLineFeedAtFileEnd" : true,
-    "maximumLineLength" : 80,
+    "maximumLineLength" : 120,
     "requireCapitalizedConstructors" : true,
     "safeContextKeyword" : ["self"],
     "requireDotNotation": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -22,7 +22,7 @@
   "indent": 2,
   "trailing": true,
   "quotmark": "single",
-  "maxlen": 80,
+  "maxlen": 120,
   "node": true,
   "globalstrict": false,
   "globals": {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/lob/hapi-bookshelf-serializer.svg)](https://travis-ci.org/lob/hapi-bookshelf-serializer)
 [![Coverage Status](https://coveralls.io/repos/lob/hapi-bookshelf-serializer/badge.svg?branch=master)](https://coveralls.io/r/lob/hapi-bookshelf-serializer?branch=master)
 
-This plugin takes [Bookshelf.js](http://bookshelfjs.org/) models that are returned via [Hapi](http://hapijs.com/)'s ```reply``` method and serializers them using [Joi](https://github.com/hapijs/joi) schemas.
+This plugin takes [Bookshelf.js](http://bookshelfjs.org/) models that are returned via [Hapi](http://hapijs.com/)'s ```reply``` method and serializes them using a user-defined `serialize` method.
 
 # Registering the Plugin
 ```javascript
@@ -12,75 +12,17 @@ var Hapi = require('hapi');
 var server = new Hapi.Server();
 
 server.register([
-  {
-    register: require('hapi-bookshelf-serializer'),
-    options: {
-      directory: 'path/to/serializers' // Required
-    }
-  }
+  require('hapi-bookshelf-serializer'),
 ], function (err) {
   // An error will be available here if anything goes wrong
 });
 ```
 
-# Options
-- ```directory``` directory where your serializers are defined
-
-# Defining Serializers
-The serializers are just [Joi](https://github.com/hapijs/joi) schemas that are applied using the ```stripUnknown``` option. Below is a basic example of related serializers.
-
-## Example
-```javascript
-// Target Object
-{
-  id: 1,
-  name: 'Test User',
-  roles: [
-    {
-      id: 1,
-      name: 'admin'
-    }
-  ]
-}
-
-// serializers/role.js
-var Joi = require('joi');
-
-module.exports = {
-  id: Joi.number().integer().required(),
-  name: Joi.string().required()
-};
-
-// serializers/user.js
-var Joi  = require('joi');
-var Role = require('./role.js');
-
-module.exports = {
-  id: Joi.number().integer().required(),
-  name: Joi.string().required(),
-  roles: Joi.array().includes(Role)
-};
-```
-
-## Request Context
-
-The Hapi request object is provided via Joi's context. This allows you to conditionally serialize fields. For example, you can hide specific keys from non-admin users.
-
-```javascript
-// serializers/user.js
-var Joi = require('joi');
-
-module.exports = Joi.object().keys({
-  id: Joi.string().required(),
-  email: Joi.string().when('$auth.credentials.admin', {
-    is: true,
-    otherwise: Joi.strip()
-  })
-});
-```
-
 # Defining Models
-Models are defined just like all [Bookshelf.js](http://bookshelfjs.org/) models, except for one small addition. A ```serializer``` property is added which references a serializer registered with this plugin. The model is matched to a serializer via a string comparison. Below is an example for defining models that could be used with the serializers above.
+Models are defined just like all [Bookshelf.js](http://bookshelfjs.org/) models, except for one small addition. A `serialize` function is added with the following signature `function (request) { }`. All model properties can be accessed in the `serialize` function via `this.get()` and the function will be passed the current Hapi request as `request`.
+
+## Serializing Related Models
+Currently there is no support in this module for automatically serializing all related models so you will need to call the function manually.
 
 ## Example
 ```javascript
@@ -89,7 +31,12 @@ var bookshelf = require('bookshelf')(require('knex')(config));
 
 module.exports = bookshelf.Model.extend({
   tableName: 'roles',
-  serializer: 'role'
+  serialize: function(request) {
+    return {
+      this.get('id'),
+      this.get('name')
+    };
+  }
 });
 
 // models/user.js
@@ -98,54 +45,17 @@ var Role      = require('./role.js');
 
 module.exports = bookshelf.Model.extend({
   tableName: 'users',
-  serializer: 'user',
-  roles: this.belongsToMany(Role)
-});
-```
-
-# Using `serialize` Instead of `serializer`
-The `serializer` provides most of the functionality that you would need for doing serialization. But we have run into cases where the logic via Joi is either too complex or not possible at all. As an alternative you can define a `serialize` function on the model that will be executed before the data is returned. All model properties can be accessed in the `serialize` function via `this.get()` and the function will be passed the current Hapi request as `request`.
-
-## Example
-```javascript
-// models/user.js
-var bookshelf = require('bookshelf')(require('knex')(config));
-
-module.exports = bookshelf.Model.extend({
-  tableName: 'users',
-  serialize: function (request) { // Hapi Request Object
+  roles: this.belongsToMany(Role),
+  serialize: function (request) {
     return {
-      id: this.get('id'),
-      name: this.get('name'),
-      type: 'user'
-    };
-  }
-});
-```
-
-## Serializing Related Models
-Currently there is no support in this module for automatically serializing all related models so you will need to call the function manually.
-
-### Example
-```javascript
-// models/user.js
-var bookshelf = require('bookshelf')(require('knex')(config));
-
-module.exports = bookshelf.Model.extend({
-  tableName: 'users',
-  roles: this.belongsToMany(Role)
-  serialize: function (request) { // Hapi Request Object
-    return {
-      id: this.get('id'),
-      name: this.get('name'),
+      this.get('id'),
+      this.get('email'),
       roles: this.related('roles').map(function (role) {
         return role.serialize(request);
-      }),
-      type: 'user'
+      });
     };
   }
 });
-
 ```
 
 This plugin pairs well with the [hapi-bookshelf-models](https://github.com/lob/hapi-bookshelf-models) plugin which makes registering models from a directory super easy.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,30 +1,5 @@
-var Boom        = require('boom');
-var fs          = require('fs');
-var Joi         = require('joi');
-var path        = require('path');
-
-var internals = {};
-
-internals.schema = {
-  directory: Joi.string().required()
-};
-
-internals.serializers = {};
-
-internals.format = function (model, request) {
-  if (model.serializer) {
-    var formattedModel = Joi.validate(model.toJSON(),
-      internals.serializers[model.serializer], {
-        stripUnknown: true,
-        context: request
-      });
-
-    if (formattedModel.error) {
-      throw formattedModel.error;
-    } else {
-      return formattedModel.value;
-    }
-  } else if (model.serialize) {
+var format = function (model, request) {
+  if (model.serialize) {
     return model.serialize(request);
   } else {
     return model;
@@ -33,56 +8,25 @@ internals.format = function (model, request) {
 
 module.exports.register = function (server, options, next) {
 
-  try {
-    Joi.assert(options, internals.schema, 'Invalid Configuration Object');
-  } catch (ex) {
-    return next(ex);
-  }
-
-  var serializerFiles = fs.readdirSync(options.directory);
-
-  serializerFiles.forEach(function (file) {
-    var serializerName = path.basename(file).replace(path.extname(file), '');
-    internals.serializers[serializerName] = require(path.join(options.directory,
-      file));
-  });
-
   server.ext('onPreResponse', function (request, reply) {
+
+    // Serialize a Collection
     if (request.response.source && request.response.source.models) {
-      try {
-        var models = request.response.source.models.map(function (model) {
-          return internals.format(model, request);
-        });
-        request.response.source = models;
+      request.response.source = request.response.source.models.map(function (model) {
+        return format(model, request);
+      });
 
-        reply.continue();
-      } catch (ex) {
-        reply(Boom.badImplementation(ex.toString()));
-      }
-    } else if (request.response.source &&
-      request.response.source instanceof Array) {
-      try {
-        request.response.source = request.response.source.map(function (val) {
-          if (val.serializer) {
-            return internals.format(val, request);
-          } else {
-            return val;
-          }
-        });
+      reply.continue();
+    } else if (request.response.source && request.response.source instanceof Array) { // Serialize Array of Models
+      request.response.source = request.response.source.map(function (val) {
+        return format(val, request);
+      });
 
-        reply.continue();
-      } catch (ex) {
-        reply(Boom.badImplementation(ex.toString()));
-      }
-    } else if (request.response.source) {
-      try {
-        var model = internals.format(request.response.source, request);
-        request.response.source = model;
+      reply.continue();
+    } else if (request.response.source) { // Seralize or Pass Through Single Object
+      request.response.source = format(request.response.source, request);
 
-        reply.continue();
-      } catch (ex) {
-        reply(Boom.badImplementation(ex.toString()));
-      }
+      reply.continue();
     } else {
       reply.continue();
     }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
     "url": "https://github.com/lob/hapi-bookshelf-serializer/issues"
   },
   "homepage": "https://github.com/lob/hapi-bookshelf-serializer",
-  "dependencies": {
-    "boom": "^2.6.1",
-    "joi": "^6.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "bookshelf": "^0.7.9",
     "chai": "^1.10.0",

--- a/test/serializers/contextModel.js
+++ b/test/serializers/contextModel.js
@@ -1,8 +1,0 @@
-var Joi = require('joi');
-
-module.exports = {
-  id: Joi.number().integer().required(),
-  name: Joi.string().required(),
-  default: Joi.number().default(Joi.ref('$headers.default')),
-  object: Joi.string().optional().default('contextModel')
-};

--- a/test/serializers/model.js
+++ b/test/serializers/model.js
@@ -1,7 +1,0 @@
-var Joi = require('joi');
-
-module.exports = {
-  id: Joi.number().integer().required(),
-  name: Joi.string().required(),
-  object: Joi.string().optional().default('model')
-};


### PR DESCRIPTION
## What

- Updated README.md with new documentation
- Updated linters to 120 characters
- Removed `serializer` pattern - now it is required to use the `serialize`method

## Why

Joi was meant for validation not formatting - we have found it adds undue complexity to what should be a simple task

@elnaz @mgartner @robinjoseph08 @brianseitel 