### PR TITLE
feat(package): add generate-changelog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1435,6 +1435,17 @@
         }
       }
     },
+    "generate-changelog": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/generate-changelog/-/generate-changelog-1.7.1.tgz",
+      "integrity": "sha512-f57zId4iD0AVRyjHHH6SwOdevrW+5ikjr6ooqlzUf7Z27DBW4BZvWZtlXmy+LShf5C52aFBCvKVwd86ZA56ObQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.16.0",
+        "github-url-from-git": "1.5.0"
+      }
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -1445,6 +1456,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "github-url-from-git": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
     "glob": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "test": "lab -t 100 --leaks --lint-fix",
     "enforce": "istanbul cover test/index.test.js --statement 100 --branch 100 --function 100 --lines 100",
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "release:patch": "changelog -p && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version patch && git push origin && git push origin --tags",
+    "release:minor": "changelog -m && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version minor && git push origin && git push origin --tags",
+    "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags"
   },
   "repository": {
     "type": "git",
@@ -34,6 +37,7 @@
   "devDependencies": {
     "bookshelf": "^0.13.3",
     "chai": "^4.1.2",
+    "generate-changelog": "^1.7.1",
     "hapi": "^17.5.2",
     "istanbul": "0.4.5",
     "knex": "^0.15.0",


### PR DESCRIPTION
What: adds generate-changelog as a dev dependency + associated scripts
Why: part of modernizing the repo, makes it easier to cut and publish new versions